### PR TITLE
repl: make double ctrl-d end REPL shell

### DIFF
--- a/rlpython/repl.py
+++ b/rlpython/repl.py
@@ -353,9 +353,12 @@ class Repl:
                 if answer == 'n':
                     return False
 
-            except(EOFError, KeyboardInterrupt):
+            except EOFError:
                 self.write('\n')
+                return True
 
+            except KeyboardInterrupt:
+                self.write('\n')
                 return False
 
     def handle_ctrl_c(self):


### PR DESCRIPTION
This allows quick exit from the REPL shell and is a quite common pattern.