### PR TITLE
aliases: Fix possible IndexError

### DIFF
--- a/rlpython/aliases.py
+++ b/rlpython/aliases.py
@@ -36,7 +36,7 @@ class Aliases:
             if not command.startswith(name):
                 continue
 
-            if(len(command) >= len(name) and
+            if(len(command) > len(name) and
                command[len(name)] in (' ', '\n', '\t')):
 
                 return '{}{}'.format(value, command[len(name):])


### PR DESCRIPTION
If name == command the line triggers an

	IndexError: string index out of range

In practise this doesn't happen because command is an entered line and
so always ends in '\n'.