### PR TITLE
command_line: Fix bogus check

### DIFF
--- a/rlpython/command_line.py
+++ b/rlpython/command_line.py
@@ -66,14 +66,10 @@ def handle_command_line():
     # local mode
     repl_kwargs = {}
 
-    for key in dir(namespace):
-        if key.startswith('_'):
-            continue
+    for key, value in vars(namespace).items():
 
         if key in ('frontend_mode',):
             continue
-
-        value = getattr(namespace, key)
 
         if value is None:
             continue


### PR DESCRIPTION
('frontend_mode') is interpreted as iterable and so the actually
implemented check is:

	key in ('f', 'r', 'o', 'n', 't', 'e', 'n', 'd', '_', 'm', 'o', 'd', 'e')

which is wrong (and ineffective as the iterable contains several
duplicates :-)