### PR TITLE
repl server: close socket on shutdown

### DIFF
--- a/rlpython/repl_server.py
+++ b/rlpython/repl_server.py
@@ -73,6 +73,8 @@ class ReplServer:
     def shutdown(self):
         self._running = False
 
+        self.sock.close()
+
         # remove unix domain socket
         if self.scheme == 'file':
             try:


### PR DESCRIPTION
Calling..
```python
rlpython.embed(bind='localhost:5000')
```
..multiple times (e.g. when done in a loop) fails with:
```
rlpython: ERROR: Address already in use
```
Close the socket on shutdown, so another embed() succeeds.